### PR TITLE
Add handling for empty lines in command-line interface

### DIFF
--- a/console.py
+++ b/console.py
@@ -1,0 +1,31 @@
+"""
+This module provides a command-line interface
+for interacting with an AirBnB clone.
+"""
+import cmd
+
+
+class HBNBCommand(cmd.Cmd):
+    prompt = '(hbnb) '
+
+    def do_EOF(self, arg):
+        """Handle end-of-file"""
+        return True
+
+    def do_quit(self, arg):
+        """Exit the program."""
+        return True
+
+    def emptyline(self):
+        pass
+
+    def default(self, line):
+        if not line:
+            return self.emptyline()
+        else:
+            print(f"Command '{line}' not recognized")
+
+
+if __name__ == '__main__':
+
+    HBNBCommand().cmdloop()


### PR DESCRIPTION
Override default behavior to prevent execution of commands when an empty line is entered followed by ENTER. Also added handling for unrecognized commands.